### PR TITLE
NECO-63: Added installation method with CococaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,45 @@ You'll also need
 If you don't have them, please register yourself and your client from [THETA Developers Website](http://contest.theta360.com/).
 
 ## Installation
-* Clone Ricoh Auth Client for Swift by running the following command:
+This section shows you two different methods to install Ricoh Auth Client for Swift in your application.  
+See [Auth Sample](https://github.com/ricohapi/auth-swift/tree/master/RicohAPIAuthSample#auth-sample) to try out a sample of Ricoh Auth Client for Swift.
+
+### CocoaPods
+* If it is your first time to use [CocoaPods](https://cocoapods.org/), run the following commands to set it up.
+```sh
+$ gem install cocoapods
+$ pod setup
+```
+
+* Go to your project directory.
+* Create a Podfile by running `pod init` ( if you do not have one yet ), and specify `RicohapiAuth` as follows:
+```ruby
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '9.0'
+use_frameworks!
+
+target 'YourAppName' do
+  pod 'RicohapiAuth', '~> 1.0.0'
+end
+```
+* Run `pod install` to install `RicohapiAuth`.
+* Open your project's workspace.
+* Choose your application scheme and run it to load the RicohAPIAuth module.
+* Install completed! See [Sample Flow](https://github.com/ricohapi/auth-swift#sample-flow) for a coding example.
+
+### Manually
+* Clone Ricoh Auth Client for Swift by running the following commands:
 ```sh
 $ git clone https://github.com/ricohapi/auth-swift.git
 ```
-
-* Open the new `auth-swift` folder, and drag the `RicohAPIAuth.xcodeproj` into the Project Navigator of your application's Xcode project.
+* Open the new `auth-swift` directory, and drag `RicohAPIAuth.xcodeproj` into the Project Navigator of your application's Xcode project.
 
     > It should appear nested underneath your application's blue project icon.
     > Whether it is above or below all the other Xcode groups does not matter.
 
 * Choose RicohAPIAuth scheme at the scheme menu of Xcode and run it.
+* Choose your application scheme and run it to load the RicohAPIAuth module.
+* Install completed! See [Sample Flow](https://github.com/ricohapi/auth-swift#sample-flow) for a coding example.
 
 ## Sample Flow
 

--- a/RicohAPIAuthSample/README.md
+++ b/RicohAPIAuthSample/README.md
@@ -6,7 +6,7 @@
 ```sh
 $ git clone https://github.com/ricohapi/auth-swift.git
 ```
-* Open `RicohAPIAuthSample.xcworkspace` in the `RicohAPIAuthSample` directory.
+* Open `RicohAPIAuth.xcworkspace` in the `RicohAPIAuth` directory.
 * Fill your Credentials in `ViewController.swift`.
     * `"### enter your client ID ###"` : replace with your client ID.
     * `"### enter your client secret ###"` : replace with your client secret.

--- a/RicohAPIAuthSample/README.md
+++ b/RicohAPIAuthSample/README.md
@@ -1,14 +1,16 @@
 # Auth Sample
-* In this sample, you can connect your Media Storage.
+* In this sample, you can connect with your Media Storage.
 
-## Settings
-* Fill your Credentials in `ViewController.swift`
+## Using the Sample
+* Clone Ricoh Auth Client for Swift by running the following commands:
+```sh
+$ git clone https://github.com/ricohapi/auth-swift.git
+```
+* Open `RicohAPIAuthSample.xcworkspace` in the `RicohAPIAuthSample` directory.
+* Fill your Credentials in `ViewController.swift`.
     * `"### enter your client ID ###"` : replace with your client ID.
     * `"### enter your client secret ###"` : replace with your client secret.
     * `"### enter your user id ###"` : replace with your user id.
     * `"### enter your user password ###"` : replace with your user password.
-
-## Using the Sample
 * Choose `RicohAPIAuthSample` scheme at the scheme menu of Xcode.
 * Run `RicohAPIAuthSample`.
-


### PR DESCRIPTION
## Changes
- README.md 
  - Added an installation method with CococaPods.
  - Modified the existing installation method for "submodule".
  - Changed headlines to adjust the changes above.
  - Fixed some grammatical mistakes.
  - Changed "folder" into "directory".
- RicohAPIAuthSample/README.md
  - Combined Setup and Using the Sample.
  - Modified  the existing installation method for "submodule".
  - Fixed a grammatical mistake.
  - Changed "folder" into "directory".
## How It Looks Like
- [README.md](https://github.com/okunoyuki/auth-swift/tree/feature/NECO-63#ricoh-auth-client-for-swift)
- [RicohAPIAuthSample/README.md](https://github.com/okunoyuki/auth-swift/tree/feature/NECO-63/RicohAPIAuthSample#auth-sample)
## Tests
- Tested all the links which were newly added or modified.
